### PR TITLE
Add flag to include Object IDs

### DIFF
--- a/Sources/ibcolortool/InterfaceBuilderFile+Colors.swift
+++ b/Sources/ibcolortool/InterfaceBuilderFile+Colors.swift
@@ -1,12 +1,14 @@
 import IBDecodable
 
+typealias Entry = (element: IBIdentifiable?, color: Color)
+
 fileprivate final class InterfaceBuilderElementVisitor {
-    var colors: [Color] = []
+    var entries: [Entry] = []
 
     func visit(element: IBElement) -> Bool {
         for child in Mirror(reflecting: element).children {
             if let color = child.value as? Color {
-                colors.append(color)
+                entries.append((element as? IBIdentifiable, color))
             }
         }
 
@@ -15,17 +17,17 @@ fileprivate final class InterfaceBuilderElementVisitor {
 }
 
 extension StoryboardFile {
-    var colors: [Color] {
+    var entries: [Entry] {
         let visitor = InterfaceBuilderElementVisitor()
         _ = document.browse(visitor.visit(element:))
-        return visitor.colors
+        return visitor.entries
     }
 }
 
 extension XibFile {
-    var colors: [Color] {
+    var entries: [Entry] {
         let visitor = InterfaceBuilderElementVisitor()
         _ = document.browse(visitor.visit(element:))
-        return visitor.colors
+        return visitor.entries
     }
 }

--- a/Tests/ibcolortoolTests/ibcolortoolTests.swift
+++ b/Tests/ibcolortoolTests/ibcolortoolTests.swift
@@ -19,28 +19,34 @@ final class IBColorToolTests: XCTestCase {
     }
 
     func testUIColorDeclarationFormatStoryboard() throws {
-         let storyboardFilePath = (try temporaryFile(contents: storyboard, extension: "storyboard")).path
-         let actual = try runIBColorTool(with: [storyboardFilePath])
-         let expected = "UIColor(red: 0.0, green: 1.0, blue: 0.0, alpha: 1.0)\n"
+        let storyboardFilePath = (try temporaryFile(contents: storyboard, extension: "storyboard")).path
+        let actual = try runIBColorTool(with: [storyboardFilePath])
+        let expected = "UIColor(red: 0.0, green: 1.0, blue: 0.0, alpha: 1.0)\n"
 
-         XCTAssertEqual(actual, expected)
-     }
+        XCTAssertEqual(actual, expected)
+    }
 
-     func testRGBHexFormatStoryboard() throws {
-         let storyboardFilePath = (try temporaryFile(contents: storyboard, extension: "storyboard")).path
-         let actual = try runIBColorTool(with: ["--format", "hex", storyboardFilePath])
-         let expected = "#00FF00\n"
+    func testRGBHexFormatStoryboard() throws {
+        let storyboardFilePath = (try temporaryFile(contents: storyboard, extension: "storyboard")).path
+        let actual = try runIBColorTool(with: ["--format", "hex", storyboardFilePath])
+        let expected = "#00FF00\n"
 
-         XCTAssertEqual(actual, expected)
-     }
+        XCTAssertEqual(actual, expected)
+    }
 
-    func testStoryboardAndXIB() throws {
+    func testStoryboardAndXIBWithObjectID() throws {
         let storyboardFilePath = (try temporaryFile(contents: storyboard, extension: "storyboard")).path
         let xibFilePath = (try temporaryFile(contents: xib, extension: "xib")).path
-        let actual = try runIBColorTool(with: ["--format", "hex", storyboardFilePath, xibFilePath])
+        let actual = try runIBColorTool(with: [
+                            "--format", "hex",
+                            "--include-object-id",
+                            storyboardFilePath,
+                            xibFilePath
+                         ])
+
         let expected = """
-        #00FF00
-        #FF9200
+        3Dd-xk-CM4\t#00FF00
+        iN0-l3-epB\t#FF9200
 
         """
 


### PR DESCRIPTION
Resolves #1 

```terminal
$ ibcolortool path/to/View.xib path/to/Scene.storyboard
3Dd-xk-CM4	UIColor(red: 1.0, green: 0.5763723, blue: 0.0, alpha: 1.0)
kPv-pK-esr	UIColor(white: 0.0, alpha: 1.0)
l4o-UU-gPT	UIColor(named: "Living Coral")
lRI-8d-Dpl	UIColor.groupTableViewBackgroundColor

$ ibcolortool path/to/View.xib path/to/Scene.storyboard | cut -f1
3Dd-xk-CM4
kPv-pK-esr
l4o-UU-gPT
lRI-8d-Dpl
```